### PR TITLE
Add a menu item to open unread in ThreadWatcher

### DIFF
--- a/src/Monitoring/ThreadWatcher.coffee
+++ b/src/Monitoring/ThreadWatcher.coffee
@@ -126,6 +126,11 @@ ThreadWatcher =
       for a in $$ 'a[title]', ThreadWatcher.list
         $.open a.href
       $.event 'CloseMenu'
+    openUnread: ->
+      return if $.hasClass @, 'disabled'
+      for a in $$ '.replies-unread a[title]', ThreadWatcher.list
+        $.open a.href
+      $.event 'CloseMenu'
     pruneDeads: ->
       return if $.hasClass @, 'disabled'
       for {siteID, boardID, threadID, data} in ThreadWatcher.getAll() when data.isDead
@@ -603,6 +608,14 @@ ThreadWatcher =
         cb: ThreadWatcher.cb.openAll
         open: ->
           @el.classList.toggle 'disabled', !ThreadWatcher.list.firstElementChild
+          true
+
+      # `Open Unread` entry
+      entries.push
+        text: 'Open unread threads'
+        cb: ThreadWatcher.cb.openUnread
+        open: ->
+          @el.classList.toggle 'disabled', !$('.replies-unread', ThreadWatcher.list)
           true
 
       # `Prune dead threads` entry


### PR DESCRIPTION
Adds a menu item to the ThreadWatcher to allow one-click opening of _all_ unread threads.

Lets you (ab)use browser tabs as a sort of todo list, of threads to get through